### PR TITLE
BugFix: Incorrect Namespace

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tiloweb\PaginationBundle\DependencyInjection;
+namespace Tiloweb\Base64Bundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;

--- a/DependencyInjection/TilowebBase64BundleExtension.php
+++ b/DependencyInjection/TilowebBase64BundleExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tiloweb\PaginationBundle\DependencyInjection;
+namespace Tiloweb\Base64Bundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Loader;
  *
  * @link http://symfony.com/doc/current/cookbook/bundles/extension.html
  */
-class TilowebPaginationExtension extends Extension
+class TilowebBase64Extension extends Extension
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
![2017-08-09 10_02_35-base64bundle](https://user-images.githubusercontent.com/14804833/29112618-b4be4188-7cee-11e7-8d12-8a1af5371f94.jpg)

J'avais cette erreur chelou... Et je me suis rendu compte que tes SymfonyPaginationBundle et SymfonyBase64Bundle avaient le même namespace.

A bientôt